### PR TITLE
Add initial compatibility extension between `AbstractGraph` and `AbstractNetwork`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,14 @@ authors = ["Sergio Sánchez Ramírez <sergio.sanchez.ramirez+git@bsc.es>"]
 version = "0.3.1"
 
 [deps]
+Bijections = "e2ed5e7c-b2de-5872-ae92-c73ca462fb04"
 DelegatorTraits = "d83dbd90-3e00-4b33-84f1-398adcf3b35e"
 
+[weakdeps]
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+
 [compat]
+Bijections = "0.2.2"
 DelegatorTraits = "0.1.2"
+Graphs = "1.13.0"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,9 @@ DelegatorTraits = "d83dbd90-3e00-4b33-84f1-398adcf3b35e"
 [weakdeps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 
+[extensions]
+NetworksGraphsExt = "Graphs"
+
 [compat]
 Bijections = "0.2.2"
 DelegatorTraits = "0.1.2"

--- a/ext/NetworksGraphExt.jl
+++ b/ext/NetworksGraphExt.jl
@@ -1,0 +1,85 @@
+module NetworksGraphExt
+
+using Networks
+using Networks: AbstractNetwork
+using Graphs: Graphs
+using DelegatorTraits
+using Bijections
+
+# generic interface compatibility
+Graphs.nv(g::AbstractNetwork) = nvertices(g)
+Graphs.ne(g::AbstractNetwork) = nedges(g)
+
+Networks.nvertices(g::Graphs.AbstractGraph) = Graphs.nv(g)
+Networks.nedges(g::Graphs.AbstractGraph) = Graphs.ne(g)
+
+# adaptation of Networks.jl to Graphs.jl
+struct SimpleAdaptedEdge{T<:Integer,E}
+    src::T
+    dst::T
+    network_edge::E
+end
+
+Graphs.src(e::SimpleAdaptedEdge) = e.src
+Graphs.dst(e::SimpleAdaptedEdge) = e.dst
+Networks.edge(e::SimpleAdaptedEdge) = e.network_edge
+
+# `T` is the Graphs.jl vertex type, `V` is the Networks.jl vertex type
+const GraphVertexBijection{T,V} = Bijection{T,V,Dict{T,V},Dict{V,T}}
+
+struct GraphsAdaptorNetwork{T<:Integer,N<:AbstractNetwork} <: AbstractGraph{T}
+    network::N
+    vertexmap::GraphVertexBijection{T,vertex_type(N)}
+
+    # TODO assert no hyperedges
+end
+
+function GraphsAdaptorNetwork{T}(g::AbstractNetwork) where {T}
+    vertexmap = GraphVertexBijection{T,vertex_type(g)}(
+        Dict{T,vertex_type(g)}(i => v for (i, v) in enumerate(vertices(g)))
+    )
+    return GraphsAdaptorNetwork{T,typeof(g)}(g, vertexmap)
+end
+
+GraphsAdaptorNetwork(g::AbstractNetwork, T=Int) = GraphsAdaptorNetwork{T}(g)
+
+## `Network` interface implementation
+DelegatorTraits.DelegatorTrait(::Networks.Network, ::GraphsAdaptorNetwork) = DelegatorTraits.DelegateToField{:network}()
+
+## `AbstractGraph` interface implementation
+Base.eltype(::Type{GraphsAdaptorNetwork{T}}) where {T} = T
+Graphs.edgetype(g::GraphsAdaptorNetwork) = SimpleAdaptedEdge{eltype(g),edge_type(g)}
+
+Graphs.ne(g::GraphsAdaptorNetwork) = nedges(g)
+Graphs.nv(g::GraphsAdaptorNetwork) = nvertices(g)
+
+Graphs.vertices(g::GraphsAdaptorNetwork) = collect(keys(g.vertexmap))
+Graphs.has_vertex(g::GraphsAdaptorNetwork, v) = haskey(g.vertexmap, v)
+
+function Graphs.edges(g::GraphsAdaptorNetwork)
+    map(all_edges(g)) do e
+        src, dst = edge_incidents(g, e)
+        SimpleAdaptedEdge{eltype(g),edge_type(g)}(g.vertexmap(src), g.vertexmap(dst), e)
+    end
+end
+
+# TODO should we also check that `src` and `dst` are valid vertices?
+Graphs.has_edge(g::GraphsAdaptorNetwork, e::SimpleAdaptedEdge) = hasedge(g, edge(e))
+
+# TODO fix when directedness arrives
+Graphs.is_directed(g::GraphsAdaptorNetwork) = false
+Graphs.outneighbors(g::GraphsAdaptorNetwork, v) = Graphs.inneighbors(g, v)
+function Graphs.inneighbors(g::GraphsAdaptorNetwork, v)
+    _edges = vertex_incidents(g, g.vertexmap[v])
+    neighbors = Set{eltype(g)}()
+    for e in _edges
+        src, dst = edge_incidents(g, e)
+        push!(neighbors, g.vertexmap(src))
+        push!(neighbors, g.vertexmap(dst))
+    end
+    return neighbors
+end
+
+Base.zero(::Type{GraphsAdaptorNetwork{T,N}}) = GraphsAdaptorNetwork{T}(N())
+
+end

--- a/ext/NetworksGraphExt.jl
+++ b/ext/NetworksGraphExt.jl
@@ -43,6 +43,8 @@ end
 
 GraphsAdaptorNetwork(g::AbstractNetwork, T=Int) = GraphsAdaptorNetwork{T}(g)
 
+Base.convert(::Type{AbstractGraph{T}}, g::AbstractNetwork) where {T} = GraphsAdaptorNetwork{T}(g)
+
 ## `Network` interface implementation
 DelegatorTraits.DelegatorTrait(::Networks.Network, ::GraphsAdaptorNetwork) = DelegatorTraits.DelegateToField{:network}()
 

--- a/ext/NetworksGraphsExt.jl
+++ b/ext/NetworksGraphsExt.jl
@@ -82,6 +82,6 @@ function Graphs.inneighbors(g::GraphsAdaptorNetwork, v)
     return neighbors
 end
 
-Base.zero(::Type{GraphsAdaptorNetwork{T,N}}) = GraphsAdaptorNetwork{T}(N())
+Base.zero(::Type{GraphsAdaptorNetwork{T,N}}) where {T,N} = GraphsAdaptorNetwork{T}(N())
 
 end

--- a/ext/NetworksGraphsExt.jl
+++ b/ext/NetworksGraphsExt.jl
@@ -1,4 +1,4 @@
-module NetworksGraphExt
+module NetworksGraphsExt
 
 using Networks
 using Networks: AbstractNetwork

--- a/ext/NetworksGraphsExt.jl
+++ b/ext/NetworksGraphsExt.jl
@@ -72,6 +72,9 @@ end
 
 # TODO should we also check that `src` and `dst` are valid vertices?
 Graphs.has_edge(g::GraphsAdaptorNetwork, e::SimpleAdaptedEdge) = hasedge(g, edge(e))
+function Graphs.has_edge(g::GraphsAdaptorNetwork, src, dst)
+    !isempty(vertex_incidents(g, g.vertexmap[src]) ∩ vertex_incidents(g, g.vertexmap[dst]))
+end
 
 # TODO fix when directedness arrives
 Graphs.is_directed(g::GraphsAdaptorNetwork) = false

--- a/ext/NetworksGraphsExt.jl
+++ b/ext/NetworksGraphsExt.jl
@@ -27,9 +27,9 @@ Networks.edge(e::SimpleAdaptedEdge) = e.network_edge
 # `T` is the Graphs.jl vertex type, `V` is the Networks.jl vertex type
 const GraphVertexBijection{T,V} = Bijection{T,V,Dict{T,V},Dict{V,T}}
 
-struct GraphsAdaptorNetwork{T<:Integer,N<:AbstractNetwork} <: Graphs.AbstractGraph{T}
+struct GraphsAdaptorNetwork{T<:Integer,N<:AbstractNetwork,V} <: Graphs.AbstractGraph{T}
     network::N
-    vertexmap::GraphVertexBijection{T,vertex_type(N)}
+    vertexmap::GraphVertexBijection{T,V}
 
     # TODO assert no hyperedges
 end
@@ -38,7 +38,8 @@ function GraphsAdaptorNetwork{T}(g::AbstractNetwork) where {T}
     vertexmap = GraphVertexBijection{T,vertex_type(g)}(
         Dict{T,vertex_type(g)}(i => v for (i, v) in enumerate(vertices(g)))
     )
-    return GraphsAdaptorNetwork{T,typeof(g)}(g, vertexmap)
+    @show vertex_type(g) typeof(vertexmap)
+    return GraphsAdaptorNetwork{T,typeof(g),vertex_type(g)}(g, vertexmap)
 end
 
 GraphsAdaptorNetwork(g::AbstractNetwork, T=Int) = GraphsAdaptorNetwork{T}(g)
@@ -47,6 +48,10 @@ Base.convert(::Type{Graphs.AbstractGraph{T}}, g::AbstractNetwork) where {T} = Gr
 
 ## `Network` interface implementation
 DelegatorTraits.DelegatorTrait(::Networks.Network, ::GraphsAdaptorNetwork) = DelegatorTraits.DelegateToField{:network}()
+
+# override to avoid infinite recursion
+Networks.nvertices(g::GraphsAdaptorNetwork) = nvertices(g.network)
+Networks.nedges(g::GraphsAdaptorNetwork) = nedges(g.network)
 
 ## `AbstractGraph` interface implementation
 Base.eltype(::Type{GraphsAdaptorNetwork{T}}) where {T} = T
@@ -59,7 +64,7 @@ Graphs.vertices(g::GraphsAdaptorNetwork) = collect(keys(g.vertexmap))
 Graphs.has_vertex(g::GraphsAdaptorNetwork, v) = haskey(g.vertexmap, v)
 
 function Graphs.edges(g::GraphsAdaptorNetwork)
-    map(all_edges(g)) do e
+    Iterators.map(all_edges(g)) do e
         src, dst = edge_incidents(g, e)
         SimpleAdaptedEdge{eltype(g),edge_type(g)}(g.vertexmap(src), g.vertexmap(dst), e)
     end
@@ -79,6 +84,10 @@ function Graphs.inneighbors(g::GraphsAdaptorNetwork, v)
         push!(neighbors, g.vertexmap(src))
         push!(neighbors, g.vertexmap(dst))
     end
+
+    # remove itself
+    # TODO keep it if self-loop?
+    delete!(neighbors, v)
     return neighbors
 end
 

--- a/ext/NetworksGraphsExt.jl
+++ b/ext/NetworksGraphsExt.jl
@@ -27,7 +27,7 @@ Networks.edge(e::SimpleAdaptedEdge) = e.network_edge
 # `T` is the Graphs.jl vertex type, `V` is the Networks.jl vertex type
 const GraphVertexBijection{T,V} = Bijection{T,V,Dict{T,V},Dict{V,T}}
 
-struct GraphsAdaptorNetwork{T<:Integer,N<:AbstractNetwork} <: AbstractGraph{T}
+struct GraphsAdaptorNetwork{T<:Integer,N<:AbstractNetwork} <: Graphs.AbstractGraph{T}
     network::N
     vertexmap::GraphVertexBijection{T,vertex_type(N)}
 
@@ -43,7 +43,7 @@ end
 
 GraphsAdaptorNetwork(g::AbstractNetwork, T=Int) = GraphsAdaptorNetwork{T}(g)
 
-Base.convert(::Type{AbstractGraph{T}}, g::AbstractNetwork) where {T} = GraphsAdaptorNetwork{T}(g)
+Base.convert(::Type{Graphs.AbstractGraph{T}}, g::AbstractNetwork) where {T} = GraphsAdaptorNetwork{T}(g)
 
 ## `Network` interface implementation
 DelegatorTraits.DelegatorTrait(::Networks.Network, ::GraphsAdaptorNetwork) = DelegatorTraits.DelegateToField{:network}()

--- a/src/Components/IncidentNetwork.jl
+++ b/src/Components/IncidentNetwork.jl
@@ -59,8 +59,11 @@ function edge_neighbors(graph::IncidentNetwork, e)
     return neighbors
 end
 
-vertex_type(::IncidentNetwork{V,E}) where {V,E} = V
-edge_type(::IncidentNetwork{V,E}) where {V,E} = E
+vertex_type(::N) where {N<:IncidentNetwork} = vertex_type(N)
+edge_type(::N) where {N<:IncidentNetwork} = edge_type(N)
+
+vertex_type(::Type{IncidentNetwork{V,E}}) where {V,E} = V
+edge_type(::Type{IncidentNetwork{V,E}}) where {V,E} = E
 
 hasvertex(graph::IncidentNetwork, v) = haskey(graph.vertexmap, v)
 hasedge(graph::IncidentNetwork, e) = haskey(graph.edgemap, e)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 Networks = "634dcf3f-6aa7-47ba-9e85-1fb329c9ebfe"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/integration/graphs.jl
+++ b/test/integration/graphs.jl
@@ -24,7 +24,7 @@ g = convert(Graphs.AbstractGraph{Int}, network)
 @test Graphs.nv(g) == 3
 @test Graphs.ne(g) == 3
 
-@test issetequal(vertices(g), [:a, :b, :c])
+@test issetequal(all_vertices(g), [:a, :b, :c])
 @test issetequal(Graphs.vertices(g), [1, 2, 3])
 @test Graphs.has_vertex(g, 1)
 @test Graphs.has_vertex(g, 2)

--- a/test/integration/graphs.jl
+++ b/test/integration/graphs.jl
@@ -1,0 +1,44 @@
+using Test
+using Networks
+using Graphs: Graphs
+
+network = Networks.IncidentNetwork{Symbol,Int}()
+addvertex!(network, :a)
+addvertex!(network, :b)
+addvertex!(network, :c)
+
+addedge!(network, 1)
+Networks.link!(network, :a, 1)
+Networks.link!(network, :b, 1)
+
+addedge!(network, 2)
+Networks.link!(network, :b, 2)
+Networks.link!(network, :c, 2)
+
+addedge!(network, 3)
+Networks.link!(network, :c, 3)
+Networks.link!(network, :a, 3)
+
+g = convert(Graphs.AbstractGraph{Int}, network)
+
+@test Graphs.nv(g) == 3
+@test Graphs.ne(g) == 3
+
+@test issetequal(vertices(g), [:a, :b, :c])
+@test issetequal(Graphs.vertices(g), [1, 2, 3])
+@test Graphs.has_vertex(g, 1)
+@test Graphs.has_vertex(g, 2)
+@test Graphs.has_vertex(g, 3)
+@test !Graphs.has_vertex(g, 4)
+
+@test issetequal(map(Networks.edge, Graphs.edges(g)), all_edges(g))
+@test issetequal(all_edges(g), [1, 2, 3])
+
+@test Graphs.is_directed(g) == false
+
+@test issetequal(Graphs.inneighbors(g, 1), [2, 3])
+@test issetequal(Graphs.inneighbors(g, 2), [1, 3])
+@test issetequal(Graphs.inneighbors(g, 3), [1, 2])
+@test issetequal(Graphs.outneighbors(g, 1), [2, 3])
+@test issetequal(Graphs.outneighbors(g, 2), [1, 3])
+@test issetequal(Graphs.outneighbors(g, 3), [1, 2])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,4 +9,6 @@ using SafeTestsets
     @safetestset "Cycles" include("unit/cycles.jl")
 end
 
-@testset "Integration" verbose = true begin end
+@testset "Integration" verbose = true begin
+    @safetestset "Graphs" include("integration/graphs.jl")
+end


### PR DESCRIPTION
The following example now works directly with GraphsRecipes.jl without an extension specific for it. For example:

```julia
using Networks
using Graphs: Graphs
using Plots
using GraphRecipes

network = Networks.IncidentNetwork{Symbol,Int}()
addvertex!(network, :a)
addvertex!(network, :b)
addvertex!(network, :c)

addedge!(network, 1)
Networks.link!(network, :a, 1)
Networks.link!(network, :b, 1)

addedge!(network, 2)
Networks.link!(network, :b, 2)
Networks.link!(network, :c, 2)

addedge!(network, 3)
Networks.link!(network, :c, 3)
Networks.link!(network, :a, 3)

g = convert(Graphs.AbstractGraph{Int}, network)

graphplot(g)
```

produces

<img width="311" height="275" alt="Captura de pantalla 2025-07-21 a las 11 25 44" src="https://github.com/user-attachments/assets/ed35cffc-d282-4da1-a643-b85511666469" />